### PR TITLE
Updated pom.xml with new repo URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <repositories>
     <repository>
       <id>m.g.o-public</id>
-      <url>https://maven.java.net/content/groups/public/</url>
+      <url>http://repo.jenkins-ci.org/public</url>
     </repository>
   </repositories>
 
@@ -44,7 +44,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>m.g.o-public</id>
-      <url>https://maven.java.net/content/groups/public/</url>
+      <url>http://repo.jenkins-ci.org/public</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.399</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.481</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <repositories>
     <repository>
       <id>m.g.o-public</id>
-      <url>http://maven.glassfish.org/content/groups/public/</url>
+      <url>https://maven.java.net/content/groups/public/</url>
     </repository>
   </repositories>
 
@@ -44,7 +44,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>m.g.o-public</id>
-      <url>http://maven.glassfish.org/content/groups/public/</url>
+      <url>https://maven.java.net/content/groups/public/</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
The old artifact and plugin repository URLs weren't working any more so I updated them to the new URLs discussed here:

http://jenkins.361315.n4.nabble.com/m-g-o-public-gt-repo-jenkins-ci-org-

Also changed the version setting to the most recent, 1.481.
